### PR TITLE
Smarter casing for name suggestions

### DIFF
--- a/src/csharpParser.ts
+++ b/src/csharpParser.ts
@@ -1,6 +1,6 @@
 import DeclarationInfo from "./declarationInfo";
 import { plural as pluralize } from "pluralize";
-import { stringBeginsWith, arrayIncludesAny, toCase, getCase } from './utils';
+import { stringBeginsWith, arrayContainsAny, toCase, getCase } from './utils';
 
 export class CsharpParser {
     public splitTypeName(typeName: string): string[] {
@@ -76,7 +76,7 @@ export class CsharpParser {
                 Suggestion = toCase("pascal", prefix + Suggestion);
             }
 
-            if (arrayIncludesAny(result, Suggestion, suggestion, _suggestion)) {
+            if (arrayContainsAny(result, Suggestion, suggestion, _suggestion)) {
                 break;
             }
 

--- a/src/csharpParser.ts
+++ b/src/csharpParser.ts
@@ -1,6 +1,6 @@
 import DeclarationInfo from "./declarationInfo";
 import { plural as pluralize } from "pluralize";
-import { stringBeginsWith, arrayIncludesAny } from './utils';
+import { stringBeginsWith, arrayIncludesAny, toCase, getCase } from './utils';
 
 export class CsharpParser {
     public splitTypeName(typeName: string): string[] {
@@ -24,7 +24,7 @@ export class CsharpParser {
         for (let i = parts.length - 1; i >= 0; i--) {
             let suggestion = "";
             for (let j = i; j < parts.length; j++) {
-                suggestion += this.toCase("pascal", parts[j]);
+                suggestion += toCase("pascal", parts[j]);
             }
 
             result.push(suggestion);
@@ -67,23 +67,23 @@ export class CsharpParser {
         const suggestions = this.getPascalSuggestions(splitTypeName);
         for (let Suggestion of suggestions) {
             // tslint:disable-next-line:variable-name
-            let _suggestion = this.toCase("_camel", Suggestion);
-            let suggestion = this.toCase("camel", Suggestion);
+            let _suggestion = toCase("_camel", Suggestion);
+            let suggestion = toCase("camel", Suggestion);
 
             if (!stringBeginsWith(Suggestion, prefix, { caseSensitive: false })) {
-                _suggestion = this.toCase("_camel", prefix + Suggestion);
-                suggestion = this.toCase("camel", prefix + Suggestion);
-                Suggestion = this.toCase("pascal", prefix + Suggestion);
+                _suggestion = toCase("_camel", prefix + Suggestion);
+                suggestion = toCase("camel", prefix + Suggestion);
+                Suggestion = toCase("pascal", prefix + Suggestion);
             }
 
             if (arrayIncludesAny(result, Suggestion, suggestion, _suggestion)) {
                 break;
             }
 
-            if (this.caseOf(userInput) === "_camel") {
+            if (getCase(userInput) === "_camel") {
                 allowedCases.pascal = false;
                 allowedCases._camel = true;
-            } else if (this.caseOf(userInput) === "pascal") {
+            } else if (getCase(userInput) === "pascal") {
                 allowedCases.pascal = true;
                 allowedCases._camel = false;
             }
@@ -100,43 +100,6 @@ export class CsharpParser {
         }
 
         return result;
-    }
-
-    private toCase(toType: 'pascal' | 'camel' | '_camel', str: string): string {
-        if (str === "_" && toType === "_camel") {
-            return "_";
-        } else if (str === "_" && toType !== "_camel") {
-            return "";
-        }
-
-        if (str[0] === "_") {
-            str = str.substr(1);
-        }
-
-        if (toType === "camel") {
-            str = str[0].toLowerCase() + str.substr(1);
-        }
-        if (toType === "_camel") {
-            str = "_" + str[0].toLowerCase() + str.substr(1);
-        }
-        if (toType === "pascal") {
-            str = str[0].toUpperCase() + str.substr(1);
-        }
-
-        return str;
-    }
-
-    private caseOf(str: string): 'pascal' | 'camel' | '_camel' {
-        const firstChar = str[0];
-        const uppercaseAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
-        if (firstChar === "_") {
-            return "_camel";
-        } else if (uppercaseAlphabet.includes(firstChar)) {
-            return "pascal";
-        } else {
-            return "camel";
-        }
     }
 }
 

--- a/src/csharpParser.ts
+++ b/src/csharpParser.ts
@@ -50,7 +50,7 @@ export class CsharpParser {
         const nameParts = this.splitTypeName(typeName);
         const result = new Set();
         const userInput = declarationInfo.getUserInput();
-        const suggestions = this.combineSuggestions(nameParts, { includePascal: isPrivate, includeUnderscore: !isPrivate && !userInput });
+        const suggestions = this.combineSuggestions(nameParts, { includePascal: !isPrivate, includeUnderscore: isPrivate && !userInput });
         const prefix = nameParts.find((part) => part.includes(userInput)) || userInput;
         if (userInput !== "") {
             suggestions.map((s) => s.includes(prefix, 0) ? s : this.combineWithUserInput(s, prefix))

--- a/src/csharpParser.ts
+++ b/src/csharpParser.ts
@@ -50,7 +50,7 @@ export class CsharpParser {
         const nameParts = this.splitTypeName(typeName);
         const result = new Set();
         const userInput = declarationInfo.getUserInput();
-        const suggestions = this.combineSuggestions(nameParts, { includePascal: isPrivate, includeUnderscore: !isPrivate && !!userInput });
+        const suggestions = this.combineSuggestions(nameParts, { includePascal: isPrivate, includeUnderscore: !isPrivate && !userInput });
         const prefix = nameParts.find((part) => part.includes(userInput)) || userInput;
         if (userInput !== "") {
             suggestions.map((s) => s.includes(prefix, 0) ? s : this.combineWithUserInput(s, prefix))

--- a/src/csharpParser.ts
+++ b/src/csharpParser.ts
@@ -1,5 +1,6 @@
 import DeclarationInfo from "./declarationInfo";
-import * as pluralizer from "pluralize";
+import { plural as pluralize } from "pluralize";
+import { stringBeginsWith, arrayIncludesAny } from './utils';
 
 export class CsharpParser {
     public splitTypeName(typeName: string): string[] {
@@ -18,22 +19,17 @@ export class CsharpParser {
         return result.map((m) => m.toLowerCase());
     }
 
-    public combineSuggestions(parts: string[], config: { includePascal?: boolean, includeUnderscore?: boolean }): string[] {
+    public getPascalSuggestions(parts: string[]): string[] {
         const result = [];
         for (let i = parts.length - 1; i >= 0; i--) {
             let suggestion = "";
             for (let j = i; j < parts.length; j++) {
-                suggestion += this.ToPascal(parts[j]);
+                suggestion += this.toCase("pascal", parts[j]);
             }
 
-            if (config.includePascal) {
-                result.push(suggestion);
-            }
-            if (config.includeUnderscore) {
-                result.push("_" + this.ToCamel(suggestion));
-            }
-            result.push(this.ToCamel(suggestion));
+            result.push(suggestion);
         }
+
         return result;
     }
 
@@ -42,24 +38,14 @@ export class CsharpParser {
             return [];
         }
 
-        const isPrivate = declarationInfo.getIsPrivate();
-        const typeName = declarationInfo.getIsPlural() ?
-            pluralizer.plural(declarationInfo.getTypeName()) :
-            declarationInfo.getTypeName();
-
-        const nameParts = this.splitTypeName(typeName);
-        const result = new Set();
         const userInput = declarationInfo.getUserInput();
-        const suggestions = this.combineSuggestions(nameParts, { includePascal: !isPrivate, includeUnderscore: isPrivate && !userInput });
-        const prefix = nameParts.find((part) => part.includes(userInput)) || userInput;
-        if (userInput !== "") {
-            suggestions.map((s) => s.includes(prefix, 0) ? s : this.combineWithUserInput(s, prefix))
-                .forEach((s) => result.add(s));
-        } else {
-            suggestions.forEach((s) => result.add(s));
-        }
+        const isPrivate = declarationInfo.getIsPrivate();
 
-        return [...result];
+        const typeName = declarationInfo.getIsPlural() ? pluralize(declarationInfo.getTypeName()) : declarationInfo.getTypeName();
+        const splitTypeName = this.splitTypeName(typeName);
+
+        const allowedCases: IAllowedCases = { camel: true, _camel: isPrivate && !userInput, pascal: !isPrivate };
+        return this.generateSuggestions(userInput, splitTypeName, allowedCases);
     }
 
     public getParsingResult(input: string): IParsingResult {
@@ -70,19 +56,94 @@ export class CsharpParser {
         return { suggestions, typeName, userInput };
     }
 
-    private ToPascal(input: string): string {
-        return input[0].toUpperCase() + input.substring(1);
+    private generateSuggestions(userInput: string, splitTypeName: string[], allowedCases: IAllowedCases): string[] {
+        let prefix = "";
+        if (userInput) {
+            prefix = splitTypeName.find((word) => word.toLowerCase().includes(userInput.toLowerCase())) || userInput;
+        }
+
+        const result: string[] = [];
+
+        const suggestions = this.getPascalSuggestions(splitTypeName);
+        for (let Suggestion of suggestions) {
+            // tslint:disable-next-line:variable-name
+            let _suggestion = this.toCase("_camel", Suggestion);
+            let suggestion = this.toCase("camel", Suggestion);
+
+            if (!stringBeginsWith(Suggestion, prefix, { caseSensitive: false })) {
+                _suggestion = this.toCase("_camel", prefix + Suggestion);
+                suggestion = this.toCase("camel", prefix + Suggestion);
+                Suggestion = this.toCase("pascal", prefix + Suggestion);
+            }
+
+            if (arrayIncludesAny(result, Suggestion, suggestion, _suggestion)) {
+                break;
+            }
+
+            if (this.caseOf(userInput) === "_camel") {
+                allowedCases.pascal = false;
+                allowedCases._camel = true;
+            } else if (this.caseOf(userInput) === "pascal") {
+                allowedCases.pascal = true;
+                allowedCases._camel = false;
+            }
+
+            if (allowedCases.pascal) {
+                result.push(Suggestion);
+            }
+            if (allowedCases.camel) {
+                result.push(suggestion);
+            }
+            if (allowedCases._camel) {
+                result.push(_suggestion);
+            }
+        }
+
+        return result;
     }
 
-    private ToCamel(input: string): string {
-        return input[0].toLowerCase() + input.substring(1);
+    private toCase(toType: 'pascal' | 'camel' | '_camel', str: string): string {
+        if (str === "_" && toType === "_camel") {
+            return "_";
+        } else if (str === "_" && toType !== "_camel") {
+            return "";
+        }
+
+        if (str[0] === "_") {
+            str = str.substr(1);
+        }
+
+        if (toType === "camel") {
+            str = str[0].toLowerCase() + str.substr(1);
+        }
+        if (toType === "_camel") {
+            str = "_" + str[0].toLowerCase() + str.substr(1);
+        }
+        if (toType === "pascal") {
+            str = str[0].toUpperCase() + str.substr(1);
+        }
+
+        return str;
     }
 
-    private combineWithUserInput(suggestion: string, userInput: string): string {
-        return userInput === "_" ?
-            userInput + suggestion :
-            userInput + this.ToPascal(suggestion);
+    private caseOf(str: string): 'pascal' | 'camel' | '_camel' {
+        const firstChar = str[0];
+        const uppercaseAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        if (firstChar === "_") {
+            return "_camel";
+        } else if (uppercaseAlphabet.includes(firstChar)) {
+            return "pascal";
+        } else {
+            return "camel";
+        }
     }
+}
+
+interface IAllowedCases {
+    pascal: boolean;
+    _camel: boolean;
+    camel: boolean;
 }
 
 export interface IParsingResult {

--- a/src/declarationInfo.ts
+++ b/src/declarationInfo.ts
@@ -14,9 +14,11 @@ export default class DeclarationInfo {
     private parameterDefinition: string;
     private userInput: string;
     private isPlural: boolean;
+    private isPrivate: boolean;
 
     constructor(input: string) {
         this.isPlural = false;
+        this.isPrivate = input.includes("private ");
         const conditionedInput = this.excludeGenerics(input);
         this.userInput = this.extractUserInput(conditionedInput);
         this.parameterDefinition = conditionedInput.substring(0, conditionedInput.length - this.userInput.length);
@@ -51,6 +53,10 @@ export default class DeclarationInfo {
 
     public getIsPlural(): boolean {
         return this.isPlural;
+    }
+
+    public getIsPrivate(): boolean {
+        return this.isPrivate;
     }
 
     private excludeGenerics(input: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,10 @@ function arrayContainsAny<T>(array: T[], ...values: T[]): boolean {
 }
 
 function toCase(toType: 'pascal' | 'camel' | '_camel', str: string): string {
+    if (!str) {
+        return "";
+    }
+
     if (str === "_" && toType === "_camel") {
         return "_";
     } else if (str === "_" && toType !== "_camel") {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,36 @@ function getCharacters(from: string, to: string): string[] {
     return result;
 }
 
+/** Determines if a string begins with a substring */
+function stringBeginsWith(str: string, substr: string, options = { caseSensitive: true }): boolean {
+    if (substr.length > str.length) {
+        return false;
+    }
+
+    if (!substr || substr.length === 0) {
+        return true;
+    }
+
+    if (!options.caseSensitive) {
+        str = str.toLowerCase();
+        substr = substr.toLowerCase();
+    }
+
+    str = str.substr(0, substr.length);
+    return str === substr;
+}
+
+/** Determines whether an array contains any of a list of values */
+function arrayIncludesAny<T>(array: T[], ...values: T[]): boolean {
+    for (const val of values) {
+        if (array.indexOf(val) > -1) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function concat(...args) {
     return args.reduce((concatenated: [any], current: [any]) => {
         return concatenated.concat(current);
@@ -16,7 +46,9 @@ function concat(...args) {
 
 export default {
     getCharacters,
+    stringBeginsWith,
+    arrayIncludesAny,
     concat,
 };
 
-export { getCharacters, concat };
+export { getCharacters, stringBeginsWith, arrayIncludesAny, concat };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,10 +10,9 @@ function getCharacters(from: string, to: string): string[] {
 
 /** Determines if a string begins with a substring */
 function stringBeginsWith(str: string, substr: string, options = { caseSensitive: true }): boolean {
-    if (substr.length > str.length) {
+    if (substr.length > str.length || str.length === 0) {
         return false;
     }
-
     if (!substr || substr.length === 0) {
         return true;
     }
@@ -28,7 +27,14 @@ function stringBeginsWith(str: string, substr: string, options = { caseSensitive
 }
 
 /** Determines whether an array contains any of a list of values */
-function arrayIncludesAny<T>(array: T[], ...values: T[]): boolean {
+function arrayContainsAny<T>(array: T[], ...values: T[]): boolean {
+    if (!array || !array.length) {
+        return false;
+    }
+    if (!values || !values.length) {
+        return true;
+    }
+
     for (const val of values) {
         if (array.indexOf(val) > -1) {
             return true;
@@ -82,7 +88,7 @@ function concat(...args) {
 }
 
 export default {
-    arrayIncludesAny,
+    arrayContainsAny,
     getCase,
     concat,
     getCharacters,
@@ -91,7 +97,7 @@ export default {
 };
 
 export {
-    arrayIncludesAny,
+    arrayContainsAny,
     getCase,
     concat,
     getCharacters,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,6 +38,43 @@ function arrayIncludesAny<T>(array: T[], ...values: T[]): boolean {
     return false;
 }
 
+function toCase(toType: 'pascal' | 'camel' | '_camel', str: string): string {
+    if (str === "_" && toType === "_camel") {
+        return "_";
+    } else if (str === "_" && toType !== "_camel") {
+        return "";
+    }
+
+    if (str[0] === "_") {
+        str = str.substr(1);
+    }
+
+    if (toType === "camel") {
+        str = str[0].toLowerCase() + str.substr(1);
+    }
+    if (toType === "_camel") {
+        str = "_" + str[0].toLowerCase() + str.substr(1);
+    }
+    if (toType === "pascal") {
+        str = str[0].toUpperCase() + str.substr(1);
+    }
+
+    return str;
+}
+
+function getCase(str: string): 'pascal' | 'camel' | '_camel' {
+    const firstChar = str[0];
+    const uppercaseAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    if (firstChar === "_") {
+        return "_camel";
+    } else if (uppercaseAlphabet.includes(firstChar)) {
+        return "pascal";
+    } else {
+        return "camel";
+    }
+}
+
 function concat(...args) {
     return args.reduce((concatenated: [any], current: [any]) => {
         return concatenated.concat(current);
@@ -45,10 +82,19 @@ function concat(...args) {
 }
 
 export default {
+    arrayIncludesAny,
+    getCase,
+    concat,
     getCharacters,
     stringBeginsWith,
-    arrayIncludesAny,
-    concat,
+    toCase,
 };
 
-export { getCharacters, stringBeginsWith, arrayIncludesAny, concat };
+export {
+    arrayIncludesAny,
+    getCase,
+    concat,
+    getCharacters,
+    stringBeginsWith,
+    toCase,
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,7 +68,11 @@ function toCase(toType: 'pascal' | 'camel' | '_camel', str: string): string {
     return str;
 }
 
-function getCase(str: string): 'pascal' | 'camel' | '_camel' {
+function getCase(str: string): 'pascal' | 'camel' | '_camel' | null {
+    if (!str) {
+        return null;
+    }
+
     const firstChar = str[0];
     const uppercaseAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 

--- a/test/csharpParser.test.ts
+++ b/test/csharpParser.test.ts
@@ -29,13 +29,27 @@ suite("C# parser", () => {
                 " public static TestConstructor(ISomeInterface ",
                 " public readonly TestConstructor(ISomeInterface "]
                 .forEach((line) => {
-                    test("should be able to provide suggested names", () => {
+                    test("should suggest PascalCase and camelCase for public names", () => {
                         const result = getSuggestions(line);
                         expect(result).to.eql([
-                            "_interface",
+                            "Interface",
                             "interface",
-                            "_someInterface",
+                            "SomeInterface",
                             "someInterface",
+                        ]);
+                    });
+                });
+
+            [" private static MyPoco[] ",
+                " private readonly static ICustomImplementedEnumerable<MyPoco> "]
+                .forEach((line) => {
+                    test("should suggest _underscore and camelCase for private names", () => {
+                        const result = getSuggestions(line);
+                        expect(result).to.eql([
+                            "pocos",
+                            "_pocos",
+                            "myPocos",
+                            "_myPocos",
                         ]);
                     });
                 });
@@ -61,29 +75,34 @@ suite("C# parser", () => {
                 expect(result).to.eql([]);
             });
 
-            test("should provide suggestions with user input", () => {
+            test("should provide pascal suggestions with pascal user input", () => {
+                const input = "  public ISomeType My";
+                const result = getSuggestions(input);
+                expect(result).to.eql(["MyType", "myType", "MySomeType", "mySomeType"]);
+            });
+
+            test("should provide camel suggestions with camel user input", () => {
                 const input = "  public ISomeType my";
                 const result = getSuggestions(input);
-                expect(result).to.contain("mySomeType");
+                expect(result).to.eql(["MyType", "myType", "MySomeType", "mySomeType"]);
             });
 
             test("should merge user input with name part if they are alike", () => {
                 const input = "  public ISomeComplexType som";
                 const result = getSuggestions(input);
-                expect(result).to.eql(["someType", "someComplexType"]);
+                expect(result).to.eql(["SomeType", "someType", "SomeComplexType", "someComplexType"]);
             });
 
             test("should not provide duplicate suggestions", () => {
                 const input = "  public ISomeType some";
                 const result = getSuggestions(input);
-                expect(result).to.eql(["someType"]);
+                expect(result).to.eql(["SomeType", "someType"]);
             });
 
             test("should provide suggestions with lowercase character after  _ ", () => {
                 const input = "  public ISomeType _";
                 const result = getSuggestions(input);
-                expect(result).to.contain("_someType");
-                expect(result).to.contain("_type");
+                expect(result).to.eql(["type", "_type", "someType", "_someType"]);
             });
 
             ["ICollection", "ObservableCollection", "DbSet", "List", "IEnumerable", "IList", "LinkedList"]
@@ -91,8 +110,7 @@ suite("C# parser", () => {
                     test("should pluralize suggested name for collections like " + typeName, () => {
                         const input = "   public " + typeName + "<" + data.WellKnownInterface + "> ";
                         const result = getSuggestions(input);
-                        expect(result).to.contain("someInterfaces");
-                        expect(result).to.contain("interfaces");
+                        expect(result).to.eql(["Interfaces", "interfaces", "SomeInterfaces", "someInterfaces"]);
                     });
                 });
 
@@ -123,7 +141,7 @@ suite("C# parser", () => {
             expect(result).to.equal(data.WellKnownInterface);
         });
 
-        test("should igore multiple keywords", () => {
+        test("should ignore multiple keywords", () => {
             const input = " private const ISomeInterface ";
             const result = target.getParsingResult(input).typeName;
             expect(result).to.equal("ISomeInterface");

--- a/test/csharpParser.test.ts
+++ b/test/csharpParser.test.ts
@@ -32,7 +32,9 @@ suite("C# parser", () => {
                     test("should be able to provide suggested names", () => {
                         const result = getSuggestions(line);
                         expect(result).to.eql([
+                            "_interface",
                             "interface",
+                            "_someInterface",
                             "someInterface",
                         ]);
                     });
@@ -85,14 +87,14 @@ suite("C# parser", () => {
             });
 
             ["ICollection", "ObservableCollection", "DbSet", "List", "IEnumerable", "IList", "LinkedList"]
-            .forEach((typeName) => {
-                test("should pluralize suggested name for collections like " + typeName, () => {
-                    const input = "   public " + typeName + "<" + data.WellKnownInterface + "> ";
-                    const result = getSuggestions(input);
-                    expect(result).to.contain("someInterfaces");
-                    expect(result).to.contain("interfaces");
+                .forEach((typeName) => {
+                    test("should pluralize suggested name for collections like " + typeName, () => {
+                        const input = "   public " + typeName + "<" + data.WellKnownInterface + "> ";
+                        const result = getSuggestions(input);
+                        expect(result).to.contain("someInterfaces");
+                        expect(result).to.contain("interfaces");
+                    });
                 });
-            });
 
             test("should not complete unfinished generic definitions", () => {
                 const input = "		IList<FooBo";

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -40,11 +40,11 @@ suite("utils", () => {
 
     suite("stringBeginsWith", () => {
         test("returns false for str = ''", () => {
-            expect(sut.stringBeginsWith('', 'abc')).to.eql(false);
+            expect(sut.stringBeginsWith("", "abc")).to.eql(false);
         });
 
         test("returns true for empty substr = ''", () => {
-            expect(sut.stringBeginsWith('abc', '')).to.eql(true);
+            expect(sut.stringBeginsWith("abc", "")).to.eql(true);
         });
 
         test("returns true when str begins with substr", () => {
@@ -75,6 +75,52 @@ suite("utils", () => {
 
         test("returns true when array contains a value", () => {
             expect(sut.arrayContainsAny([1, 2, 3], 4, 5, 6)).to.eql(false);
+        });
+    });
+
+    suite("getCase and toCase", () => {
+        test("getCase for pascal", () => {
+            expect(sut.getCase("PascalText")).to.eql("pascal");
+        });
+
+        test("getCase for camel", () => {
+            expect(sut.getCase("camelText")).to.eql("camel");
+        });
+
+        test("getCase for _camel", () => {
+            expect(sut.getCase("_underscoreText")).to.eql("_camel");
+        });
+
+        test("getCase for '_'", () => {
+            expect(sut.getCase("_")).to.eql("_camel");
+        });
+
+        test("getCase for ''", () => {
+            expect(sut.getCase("")).to.eql(null);
+        });
+
+        test("toCase for ''", () => {
+            expect(sut.toCase("pascal", "")).to.eql("");
+        });
+
+        test("toCase _camel for '_'", () => {
+            expect(sut.toCase("_camel", "_")).to.eql("_");
+        });
+
+        test("toCase Pascal for '_'", () => {
+            expect(sut.toCase("pascal", "_")).to.eql("");
+        });
+
+        test("toCase _camel", () => {
+            expect(sut.toCase("_camel", "MyClass")).to.eql("_myClass");
+        });
+
+        test("toCase camel", () => {
+            expect(sut.toCase("camel", "_iValuePrivacy")).to.eql("iValuePrivacy");
+        });
+
+        test("toCase Pascal", () => {
+            expect(sut.toCase("pascal", "aWildCamel")).to.eql("AWildCamel");
         });
     });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -55,4 +55,26 @@ suite("utils", () => {
             expect(sut.stringBeginsWith("abcABC i am testing", "abcd")).to.eql(false);
         });
     });
+
+    suite("arrayContainsAny", () => {
+        test("returns false for array = []", () => {
+            expect(sut.arrayContainsAny([], 2)).to.eql(false);
+        });
+
+        test("returns true for values = []", () => {
+            expect(sut.arrayContainsAny([1, 2, 3], ...[])).to.eql(true);
+        });
+
+        test("returns true for values = undefined", () => {
+            expect(sut.arrayContainsAny([1, 2, 3])).to.eql(true);
+        });
+
+        test("returns true when array contains a value", () => {
+            expect(sut.arrayContainsAny([1, 2, 3], 2, 3)).to.eql(true);
+        });
+
+        test("returns true when array contains a value", () => {
+            expect(sut.arrayContainsAny([1, 2, 3], 4, 5, 6)).to.eql(false);
+        });
+    });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -6,8 +6,8 @@ suite("utils", () => {
         [{ from: "a", to: "d", expectedResult: ["a", "b", "c", "d"] },
         { from: "a", to: "b", expectedResult: ["a", "b"] },
         { from: "A", to: "D", expectedResult: ["A", "B", "C", "D"] },
-        { from: "A", to: "A", expectedResult: ["A"] }
-        ].forEach(testCase => {
+        { from: "A", to: "A", expectedResult: ["A"] },
+        ].forEach((testCase) => {
             suite(`from ${testCase.from} to ${testCase.to}`, () => {
                 let result;
                 suiteSetup(() => {
@@ -35,6 +35,24 @@ suite("utils", () => {
         test("three argument should return concatenation of three arrays", () => {
             const result = sut.concat(["a", "b"], ["c"], "d", "e");
             expect(result).to.eql(["a", "b", "c", "d", "e"]);
+        });
+    });
+
+    suite("stringBeginsWith", () => {
+        test("returns false for str = ''", () => {
+            expect(sut.stringBeginsWith('', 'abc')).to.eql(false);
+        });
+
+        test("returns true for empty substr = ''", () => {
+            expect(sut.stringBeginsWith('abc', '')).to.eql(true);
+        });
+
+        test("returns true when str begins with substr", () => {
+            expect(sut.stringBeginsWith("abcABC i am testing", "abcABC i")).to.eql(true);
+        });
+
+        test("returns false when str doesn't begin with substr", () => {
+            expect(sut.stringBeginsWith("abcABC i am testing", "abcd")).to.eql(false);
         });
     });
 });


### PR DESCRIPTION
**Added smarter casing for suggestions:**

User hasn't started typing yet:
- If token is `private` suggest `camelCase` and `_camelCase`.
- Otherwise (all other access levels), suggest `PascalCase` and `camelCase`

User has started typing:
- if input is `_camelCase`, suggest `_camelCase` and `camelCase` regardless of access level.
- if input is `PascalCase`, **don't** suggest `_camelCase`
- Otherwise use access level rules

examples:
```
class TestClass
{
    public IList<MyType>          // suggests [ 'myTypes', 'MyTypes', 'types', 'Types' ]
    private readonly IMyService   // suggests [ 'myService', '_myService', 'service', '_service' ]
    Enumerable<User> _            // suggests [ '_users', 'users' ]
    Enumerable<User> u            // suggests [ 'users', 'Users' ]
    Enumerable<User> U            // suggests [ 'Users', 'users' ]
}
```